### PR TITLE
Icon の maxTextureSize を 512 に縮小

### DIFF
--- a/src/Editor/MornAspect_Icon.png.meta
+++ b/src/Editor/MornAspect_Icon.png.meta
@@ -72,7 +72,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 512
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1


### PR DESCRIPTION
アイコンの maxTextureSize を 2048 → 512 に縮小。